### PR TITLE
Add a restriction to CrossOrigin annotations

### DIFF
--- a/.atomist.yml
+++ b/.atomist.yml
@@ -106,3 +106,16 @@ editor:
     - "fieldName": "surveyName"
     - "fieldType": "String"
 
+---
+kind: "operation"
+client: "atomist-bot"
+editor:
+  name: "RestrictCORS"
+  group: "satellite-of-love"
+  artifact: "rest-service-generator"
+  version: "0.12.8"
+  origin:
+    repo: "git@github.com:satellite-of-love/workflow-rugs"
+    branch: "master"
+    sha: "b0910b4"
+

--- a/src/main/java/com/jessitron/AggregatedSurveyResultController.java
+++ b/src/main/java/com/jessitron/AggregatedSurveyResultController.java
@@ -11,7 +11,7 @@ import java.util.List;
 @RestController
 public class AggregatedSurveyResultController {
 
-    @CrossOrigin()
+    @CrossOrigin(origins = "http://localhost:8000")
     @RequestMapping(path = "/aggregatedResults", method = RequestMethod.POST)
     public AggregatedSurveyResult aggregatedSurveyResult
             (@RequestBody() Survey survey) {

--- a/src/main/java/com/jessitron/VoteController.java
+++ b/src/main/java/com/jessitron/VoteController.java
@@ -7,7 +7,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 public class VoteController {
 
-    @CrossOrigin()
+    @CrossOrigin(origins = "http://localhost:8000")
     @RequestMapping(path = "/vote", method = RequestMethod.POST)
     public SurveyResultResponse vote(
             @RequestBody() Vote response) {


### PR DESCRIPTION
This is a recommended change from your friendly security advisers.
        
        While allowing cross-origin requests is essential for some local testing, it is 
        otherwise discouraged by ... people. As long as your local front end is at localhost:8080,
        you'll be able to test.

        If there is a particular reason that your service should allow more requests (like, it's a public API)
        then please comment on this PR and then close it or remove individual endpoints' changes.
        

Created by Atomist Editor `RestrictCORS`
```
---
kind: "operation"
client: "atomist-bot"
editor:
  name: "RestrictCORS"
  group: "satellite-of-love"
  artifact: "rest-service-generator"
  version: "0.12.8"
  origin:
    repo: "git@github.com:satellite-of-love/workflow-rugs"
    branch: "master"
    sha: "b0910b4"

```