### PR TITLE
Add a restriction to CrossOrigin annotations

### DIFF
--- a/.atomist.yml
+++ b/.atomist.yml
@@ -120,3 +120,13 @@ editor:
     - "artifact": "survey-source"
     - "desiredVersion": "0.3.2"
 
+---
+kind: "operation"
+client: "com.atomist:rug"
+version: "1.0.0-20170609011313"
+editor:
+  name: "RestrictCORS"
+  group: "satellite-of-love"
+  artifact: "rest-service-generator"
+  version: "1.13.23"
+

--- a/src/main/java/com/jessitron/AggregatedSurveyResultController.java
+++ b/src/main/java/com/jessitron/AggregatedSurveyResultController.java
@@ -11,7 +11,7 @@ import java.util.List;
 @RestController
 public class AggregatedSurveyResultController {
 
-    @CrossOrigin()
+    @CrossOrigin(origins = "http://localhost:8000")
     @RequestMapping(path = "/aggregatedResults", method = RequestMethod.POST)
     public AggregatedSurveyResult aggregatedSurveyResult
             (@RequestBody() Survey survey) {

--- a/src/main/java/com/jessitron/VoteController.java
+++ b/src/main/java/com/jessitron/VoteController.java
@@ -10,7 +10,7 @@ public class VoteController {
     //TODO: offer an endpoint that takes only the title
     // and fetches the options from survey-source
 
-    @CrossOrigin()
+    @CrossOrigin(origins = "http://localhost:8000")
     @RequestMapping(path = "/vote", method = RequestMethod.POST)
     public SurveyResultResponse vote(
             @RequestBody() Vote response) {


### PR DESCRIPTION
This is a recommended change from your friendly security advisers.
        
        While allowing cross-origin requests is essential for some local testing, it is 
        otherwise discouraged by ... people. As long as your local front end is at localhost:8080,
        you'll be able to test.

        If there is a particular reason that your service should allow more requests (like, it's a public API)
        then please comment on this PR and then close it or remove individual endpoints' changes.
        

Created by Atomist Editor `RestrictCORS`
```
---
kind: "operation"
client: "com.atomist:rug"
version: "1.0.0-20170609011313"
editor:
  name: "RestrictCORS"
  group: "satellite-of-love"
  artifact: "rest-service-generator"
  version: "1.13.23"

```